### PR TITLE
Coq 8.13 and OCaml 4.12 support

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -17,12 +17,10 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'coqorg/coq:8.7'
-          - 'coqorg/coq:8.8'
-          - 'coqorg/coq:8.9'
           - 'coqorg/coq:8.10'
           - 'coqorg/coq:8.11'
           - 'coqorg/coq:8.12'
+          - 'coqorg/coq:8.13'
           - 'coqorg/coq:dev'
       fail-fast: false
     steps:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ axiomatization and extraction to OCaml native integers.
 - Compatible Coq versions: 8.7 or later (use releases for other Coq versions)
 - Compatible OCaml versions: 4.05 or later (not tested on previous versions)
 - Additional dependencies:
+  - OCamlbuild
   - [MathComp](https://math-comp.github.io) 1.7.0 or later (`algebra` suffices)
 - Coq namespace: `Bits`
 - Related publication(s):

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ the following command:
 make verify
 ```
 
+For 8bit, the verification process should finish in few seconds. However
+for 16-bit, depending on your computer speed, it could take more than 6
+hours.
+
 [bitstosets]: https://hal.archives-ouvertes.fr/hal-01251943/document
 [coqasm]: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/12/coqasm.pdf
 [xprovedkennedy]: https://x86proved.codeplex.com/SourceControl/network/forks/andrewjkennedy/x86proved/latest#src/bits.v

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ axiomatization and extraction to OCaml native integers.
 - Coq-community maintainer(s):
   - Anton Trunov ([**@anton-trunov**](https://github.com/anton-trunov))
 - License: [Apache License 2.0](LICENSE)
-- Compatible Coq versions: 8.7 or later (use releases for other Coq versions)
+- Compatible Coq versions: 8.10 or later (use releases for other Coq versions)
 - Compatible OCaml versions: 4.05 or later (not tested on previous versions)
 - Additional dependencies:
   - OCamlbuild

--- a/_CoqProject
+++ b/_CoqProject
@@ -2,6 +2,8 @@
 
 -arg -w -arg -notation-overridden
 -arg -w -arg -ambiguous-paths
+-arg -w -arg -extraction-opaque-accessed
+-arg -w -arg -extraction-reserved-identifier
 
 src/ssrextra/nat.v
 src/ssrextra/tuple.v

--- a/coq-bits.opam
+++ b/coq-bits.opam
@@ -18,10 +18,10 @@ axiomatization and extraction to OCaml native integers."""
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "ocaml" {(>= "4.05" & < "4.10~")}
-  "coq" {(>= "8.7" & < "8.13~") | (= "dev")}
+  "ocaml" {(>= "4.05" & < "4.13~")}
+  "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
   "ocamlbuild" 
-  "coq-mathcomp-algebra" {(>= "1.7" & < "1.12~") | (= "dev")}
+  "coq-mathcomp-algebra" {(>= "1.7" & < "1.13~") | (= "dev")}
 ]
 
 tags: [

--- a/coq-bits.opam
+++ b/coq-bits.opam
@@ -20,6 +20,7 @@ install: [make "install"]
 depends: [
   "ocaml" {(>= "4.05" & < "4.10~")}
   "coq" {(>= "8.7" & < "8.13~") | (= "dev")}
+  "ocamlbuild" 
   "coq-mathcomp-algebra" {(>= "1.7" & < "1.12~") | (= "dev")}
 ]
 

--- a/meta.yml
+++ b/meta.yml
@@ -141,6 +141,10 @@ documentation: |-
   make verify
   ```
 
+  For 8bit, the verification process should finish in few seconds. However
+  for 16-bit, depending on your computer speed, it could take more than 6
+  hours.
+
   [bitstosets]: https://hal.archives-ouvertes.fr/hal-01251943/document
   [coqasm]: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/12/coqasm.pdf
   [xprovedkennedy]: https://x86proved.codeplex.com/SourceControl/network/forks/andrewjkennedy/x86proved/latest#src/bits.v

--- a/meta.yml
+++ b/meta.yml
@@ -48,19 +48,17 @@ license:
 
 supported_ocaml_versions:
   text: 4.05 or later (not tested on previous versions)
-  opam: '{(>= "4.05" & < "4.10~")}'
+  opam: '{(>= "4.05" & < "4.13~")}'
 
 supported_coq_versions:
-  text: 8.7 or later (use releases for other Coq versions)
-  opam: '{(>= "8.7" & < "8.13~") | (= "dev")}'
+  text: 8.10 or later (use releases for other Coq versions)
+  opam: '{(>= "8.10" & < "8.14~") | (= "dev")}'
 
 tested_coq_opam_versions:
-- version: '8.7'
-- version: '8.8'
-- version: '8.9'
 - version: '8.10'
 - version: '8.11'
 - version: '8.12'
+- version: '8.13'
 - version: dev
 
 dependencies:
@@ -69,7 +67,7 @@ dependencies:
   description: OCamlbuild
 - opam:
     name: coq-mathcomp-algebra
-    version: '{(>= "1.7" & < "1.12~") | (= "dev")}'
+    version: '{(>= "1.7" & < "1.13~") | (= "dev")}'
   description: |-
     [MathComp](https://math-comp.github.io) 1.7.0 or later (`algebra` suffices)
 

--- a/meta.yml
+++ b/meta.yml
@@ -65,6 +65,9 @@ tested_coq_opam_versions:
 
 dependencies:
 - opam:
+    name: ocamlbuild
+  description: OCamlbuild
+- opam:
     name: coq-mathcomp-algebra
     version: '{(>= "1.7" & < "1.12~") | (= "dev")}'
   description: |-

--- a/src/extraction/magic.patch
+++ b/src/extraction/magic.patch
@@ -2,7 +2,3 @@
 <   simplPred (fun _ -> true)
 ---
 >   Obj.magic simplPred (fun _ -> true)
-836c836
-<       (Obj.magic mixin_base (assert false (* Proj Args *)) c.mixin) }
----
->       (Obj.magic mixin_base ((* Proj Args *)) c.mixin) }

--- a/src/spec/operations.v
+++ b/src/spec/operations.v
@@ -190,6 +190,8 @@ Definition bRange {n} (p q: BITS n) := bIota p (subB q p).
     Notations
   ---------------------------------------------------------------------------*)
 
+Declare Scope bits_scope.
+
 Module BitsNotations.
 Infix "<<" := shlBn (at level 30, no associativity) : bits_scope.
 Infix ">>" := shrBn (at level 30, no associativity) : bits_scope.

--- a/src/spec/operations/properties.v
+++ b/src/spec/operations/properties.v
@@ -332,7 +332,7 @@ apply expn_gt0.
 Qed.
 
 Lemma fromNatDouble b n : forall m, cons_tuple b (fromNat (n:=n) m) = fromNat (b + m.*2).
-Proof. move => m. rewrite /fromNat-/fromNat/=. rewrite odd_add odd_double.
+Proof. move => m. rewrite /fromNat-/fromNat/=. rewrite oddD odd_double.
 destruct b. simpl. by rewrite uphalf_double.
 by rewrite add0n half_double.
 Qed.
@@ -436,7 +436,7 @@ split.
 +
 rewrite /negB.
 rewrite /fromNat-/fromNat. rewrite invBCons IH2 /=!theadCons!beheadCons.
-rewrite odd_sub. rewrite odd_power2/=.
+rewrite oddB. rewrite odd_power2/=.
 case ODD: (odd m).
 - rewrite expnS mul2n. rewrite half_sub.
   rewrite uphalf_half ODD -subn1 subnDA. done. apply (ltnW H).
@@ -447,7 +447,7 @@ case ODD: (odd m).
   by rewrite subn_gt0.
   apply (ltnW H).
 - rewrite expnS mul2n. apply (ltnW H).
-rewrite /fromNat-/fromNat invBCons IH2. rewrite odd_sub/=.
+rewrite /fromNat-/fromNat invBCons IH2. rewrite oddB/=.
 rewrite odd_power2subn1/=. rewrite -!subn1 -!subnDA expnS mul2n.
 rewrite half_sub. done. apply H.
 rewrite expnS mul2n. apply leq_subn; last done. rewrite -mul2n -expnS. apply expn_gt0.
@@ -586,7 +586,7 @@ induction n.
 + move => b p1 p2. rewrite 2!toNatNil. by destruct b.
 + move => b. case/tupleP => [b1 p1]. case/tupleP => [b2 p2].
   rewrite /fromNat-/fromNat/=.
-  rewrite !theadCons !beheadCons !toNatCons !odd_add !odd_double /=.
+  rewrite !theadCons !beheadCons !toNatCons !oddD !odd_double /=.
   case e: (fullAdder b b1 b2) => [carry' b0].
   specialize (IHn carry' p1 p2). rewrite IHn /= addnA.
   assert (b0 = odd b (+) (odd b1 (+) false) (+) (odd b2 (+) false)).
@@ -1348,7 +1348,7 @@ apply: leq_trans H. apply (ltnW B2).
 rewrite (divn_small H). done.
 
 apply negbT in P. rewrite -leqNgt in P.
-rewrite -(addnBA _ P) divnDl; last done. rewrite divnn POS odd_add/=.
+rewrite -(addnBA _ P) divnDl; last done. rewrite divnn POS oddD/=.
 rewrite negbK.
 assert (toNat p1 - toNat p2 < 2^n).
 assert (H := leq_subr (toNat p2) (toNat p1)).
@@ -1409,7 +1409,7 @@ Qed.
 Lemma toNat_rorB n (p: BITS n.+1) : toNat (rorB p) = (toNat p)./2 + (toNat p %% 2) * 2^n.
 Proof. case/tupleP: p => [b p].
 rewrite /rorB toNat_joinmsb /droplsb/splitlsb beheadCons theadCons toNatCons /=.
-rewrite half_bit_double. rewrite modn2 odd_add odd_double addnC. by destruct b.
+rewrite half_bit_double. rewrite modn2 oddD odd_double addnC. by destruct b.
 Qed.
 
 Lemma toNat_rolB n (p: BITS n.+1) : toNat (rolB p) = (toNat p %% 2^n).*2 + toNat p %/ 2^n.

--- a/src/spec/operations/properties.v
+++ b/src/spec/operations/properties.v
@@ -1967,18 +1967,19 @@ Canonical Structure BITS_finGroupType :=
 End Structures.
 
 (* TODO: Extract Minimal Working Example for 'Failed' below *)
-Parameter n: nat.
-Parameter q: 'I_n.+2.
-
+(* Parameter n: nat.
+Parameter q: 'I_n.+2. *)
+(*
 Set Printing All.
 Check (n%:R)%R.
+*)
 (*
-@GRing.natmul (GRing.Ring.zmodType ?t0) (GRing.one ?t0) n
-     : GRing.Zmodule.sort (GRing.Ring.zmodType ?t0)
+@GRing.natmul (GRing.Ring.zmodType ?t) (GRing.one ?t) n
+     : GRing.Zmodule.sort (GRing.Ring.zmodType ?t)
 where
-?t0 : [ |- GRing.Ring.type] 
+?t : [ |- GRing.Ring.type]
  *)
-Check (q * n%:R)%R.
+(* Check (q * n%:R)%R. *)
 (*
 @GRing.mul (Zp_ringType n) q
   (@GRing.natmul (GRing.Ring.zmodType (Zp_ringType n))

--- a/src/spec/spec/properties.v
+++ b/src/spec/spec/properties.v
@@ -30,7 +30,7 @@ Proof. by rewrite (tuple0 p). Qed.
 Lemma toNatK n : cancel (@toNat n) (@fromNat n).
 Proof. induction n; first (move => p; apply trivialBits).
 + case/tupleP => b x. rewrite toNatCons/fromNat-/fromNat /= half_bit_double.
-rewrite IHn odd_add odd_double. by case b.
+rewrite IHn oddD odd_double. by case b.
 Qed.
 
 (* Hence toNat is injective *)
@@ -77,8 +77,8 @@ Lemma fromNat_wrap n : forall m, fromNat (n:=n) m = fromNat (n:=n) (m + 2^n).
 Proof. induction n => //.
 rewrite expnS.
 move => m.
-case ODD: (odd m); rewrite /fromNat-/fromNat /=ODD odd_add odd_mul/=ODD/= halfD ODD/=.
-specialize (IHn m./2). by rewrite odd_mul/= add0n mul2n doubleK IHn.
+case ODD: (odd m); rewrite /fromNat-/fromNat /=ODD oddD oddM/=ODD/= halfD ODD/=.
+specialize (IHn m./2). by rewrite oddM/= add0n mul2n doubleK IHn.
 specialize (IHn m./2). by rewrite add0n mul2n doubleK IHn.
 Qed.
 

--- a/src/ssrextra/nat.v
+++ b/src/ssrextra/nat.v
@@ -37,7 +37,7 @@ Proof.
 induction a => b H.
 + by rewrite !subn0 doubleK.
 + rewrite half_subn1. rewrite uphalf_half. rewrite IHa.
-  rewrite odd_sub. rewrite odd_double/=. rewrite -subn1.
+  rewrite oddB. rewrite odd_double/=. rewrite -subn1.
   rewrite uphalf_half.
 case ODD: (odd a).
   by rewrite add1n subn1.


### PR DESCRIPTION
- Minor cleanups to remove some warnings.
- Fixed ML diff (removed unused hunk)
- Updated dependencies in OPAM package specification
- Tested Coq 8.13.2 and OCaml 4.12.01. This version passes `make verify` test (which took ~7 hours to complete).