### PR TITLE
CI: support for Coq 8.15 & 8.16 and Mathcomp 1.14 & 1.15

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -17,7 +17,8 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'mathcomp/mathcomp-dev:coq-dev'
+          - 'mathcomp/mathcomp:1.15.0-coq-8.16'
+          - 'mathcomp/mathcomp:1.14.0-coq-8.15'
           - 'mathcomp/mathcomp:1.13.0-coq-8.14'
           - 'mathcomp/mathcomp:1.12.0-coq-8.13'
           - 'mathcomp/mathcomp:1.12.0-coq-8.12'
@@ -30,6 +31,7 @@ jobs:
         with:
           opam_file: 'coq-bits.opam'
           custom_image: ${{ matrix.image }}
+
 
 # See also:
 # https://github.com/coq-community/docker-coq-action#readme

--- a/coq-bits.opam
+++ b/coq-bits.opam
@@ -18,10 +18,10 @@ axiomatization and extraction to OCaml native integers."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "ocaml" {(>= "4.05" & < "4.13~")}
-  "coq" {(>= "8.10" & < "8.15~") | (= "dev")}
+  "ocaml" {(>= "4.05" & < "4.15~")}
+  "coq" {(>= "8.10" & < "8.17~")}
   "ocamlbuild" 
-  "coq-mathcomp-algebra" {(>= "1.12" & < "1.14~") | (= "dev")}
+  "coq-mathcomp-algebra" {(>= "1.12" & < "1.16~")}
 ]
 
 tags: [

--- a/meta.yml
+++ b/meta.yml
@@ -48,15 +48,17 @@ license:
 
 supported_ocaml_versions:
   text: 4.05 or later (not tested on previous versions)
-  opam: '{(>= "4.05" & < "4.13~")}'
+  opam: '{(>= "4.05" & < "4.15~")}'
 
 supported_coq_versions:
   text: 8.10 or later (use releases for other Coq versions)
-  opam: '{(>= "8.10" & < "8.15~") | (= "dev")}'
+  opam: '{(>= "8.10" & < "8.17~")}'
 
 tested_coq_opam_versions:
-- version: 'coq-dev'
-  repo: 'mathcomp/mathcomp-dev'
+- version: '1.15.0-coq-8.16'
+  repo: 'mathcomp/mathcomp'
+- version: '1.14.0-coq-8.15'
+  repo: 'mathcomp/mathcomp'
 - version: '1.13.0-coq-8.14'
   repo: 'mathcomp/mathcomp'
 - version: '1.12.0-coq-8.13'
@@ -74,7 +76,7 @@ dependencies:
   description: OCamlbuild
 - opam:
     name: coq-mathcomp-algebra
-    version: '{(>= "1.12" & < "1.14~") | (= "dev")}'
+    version: '{(>= "1.12" & < "1.16~")}'
   description: |-
     [MathComp](https://math-comp.github.io) 1.12.0 or later (`algebra` suffices)
 


### PR DESCRIPTION
Also, update the upper boundary on the OCaml compiler version